### PR TITLE
add CORS headers to allow use of etherpad API inside browsers

### DIFF
--- a/express.js
+++ b/express.js
@@ -7,6 +7,7 @@ exports.expressCreateServer = function (hook_name, args, cb) {
 
     exportMarkdown.getPadMarkdownDocument(padID, revision, function(err, result) {
       res.contentType('plain/text');
+      res.header('Access-Control-Allow-Origin', '*');
       res.send(result);
     });
   });


### PR DESCRIPTION
This pull request add CORS headers to allow use of etherpad API inside browsers.